### PR TITLE
Use getopt_long() to standardize command processing

### DIFF
--- a/cmdline.h
+++ b/cmdline.h
@@ -1,3 +1,3 @@
 
 
-int cmdline_main(int argc, const char * argv[]);
+int cmdline_main(int argc, char * const *argv);

--- a/cmdline.mm
+++ b/cmdline.mm
@@ -1,13 +1,16 @@
+extern "C"
+{
+#import <getopt.h>
+}
+
+
 #import <Foundation/Foundation.h>
 
 #import <dlfcn.h>
 
 #import "utils.h"
 
-
-
-
-int cmdline_main(int argc, const char * argv[])
+int cmdline_main(int argc, char * const*argv)
 {
 	//exit(0);
 	
@@ -22,109 +25,48 @@ int cmdline_main(int argc, const char * argv[])
 		
 		bool listDisplays = 0;
 		bool listModes = 0;
-		
-		for(int i=1; i<argc; i++)
-		{
-			if(argv[i][0]=='-')
-			{
-				if(strlen(argv[i])==2)
-				{
-					switch(argv[i][1])
-					{
-						case 'w':
-							i++;
-							width = atoi(argv[i]);
-							break;
-						case 'h':
-							i++;
-							height = atoi(argv[i]);
-							break;
-						case 's':
-							i++;
-							scale = atof(argv[i]);
-							break;
-						case 'b':
-							i++;
-							bitRes = atoi(argv[i]);
-							break;
-						case 'd':
-							i++;
-							displayNo = atoi(argv[i]);
-							break;
-						case 'l':
-							if(argv[i][2]=='m')
-								listModes = 1;
-							if(argv[i][2]=='d')
-								listDisplays = 1;
-							break;
-						case 'r':
-							i++;
-							rotation = atof(argv[i]);
-							break;
-						default:
-							return -1;
-					}
-					continue;
-				}
-				if(argv[i][1]=='l' && strlen(argv[i])==3)
-				{
-					if(argv[i][2]=='m')
-						listModes = 1;
-					else if(argv[i][2]=='d')
-						listDisplays = 1;
-					else
-						return -1;
-					continue;
-				}
-				if(argv[i][1]=='-')
-				{
-					if(!strcmp(&argv[i][2], "width"))
-					{
-						i++;
-						width = atoi(argv[i]);
-					}
-					else if(!strcmp(&argv[i][2], "height"))
-					{
-						i++;
-						height = atoi(argv[i]);
-					}
-					else if(!strcmp(&argv[i][2], "scale"))
-					{
-						i++;
-						scale = atof(argv[i]);
-					}
-					else if(!strcmp(&argv[i][2], "bits"))
-					{
-						i++;
-						bitRes = atoi(argv[i]);
-					}
-					else if(!strcmp(&argv[i][2], "display"))
-					{
-						i++;
-						displayNo = atoi(argv[i]);
-					}
-					else if(!strcmp(&argv[i][2], "displays"))
-					{
-						listDisplays = 1;
-					}
-					else if(!strcmp(&argv[i][2], "modes"))
-					{
-						listModes = 1;
-					}
-					else if(!strcmp(&argv[i][2], "rotation"))
-					{
-						i++;
-						rotation = atof(argv[i]);
-					}
-					else
-					{
-						return -1;
-					}
-					continue;
-				}
+
+		static struct option longopts[] = {
+			{"width", required_argument, NULL, 'w'},
+			{"height", required_argument, NULL, 'h'},
+			{"scale", required_argument, NULL, 's'},
+			{"bits", required_argument, NULL, 'b'},
+			{"display", required_argument, NULL, 'd'},
+			{"displays",no_argument, NULL, 'l'},
+			{"modes", no_argument, NULL, 'm'},
+			{NULL, 0, NULL, 0},
+		};
+
+		int ch;
+		while ((ch = getopt_long(argc, argv, "w:h:s:b:d:lmr:", longopts, NULL)) != -1) {
+			switch (ch) {
+			case 'w':
+				width = atoi(optarg);
+				break;
+			case 'h':
+				height = atoi(optarg);
+				break;
+			case 's':
+				scale = atof(optarg);
+				break;
+			case 'b':
+				bitRes = atoi(optarg);
+				break;
+			case 'd':
+				displayNo = atoi(optarg);
+				break;
+			case 'l':
+				listDisplays = 1;
+				break;
+			case 'm':
+				listModes = 1;
+				break;
+			case 'r':
+				rotation = atof(optarg);
+				break;
+			default:
 				return -1;
 			}
-			return -1;
 		}
 
 		uint32_t nDisplays;

--- a/main.mm
+++ b/main.mm
@@ -7,7 +7,7 @@
 #import "cmdline.h"
 
 
-int main(int argc, const char* argv[])
+int main(int argc, char* argv[])
 {
 	int ret = -1;
 	if(argc > 1)
@@ -23,8 +23,8 @@ int main(int argc, const char* argv[])
 						"  --scale    (-s)  Scale (2.0 = Retina, default=current)\n"
 						"  --bits     (-b)  Color depth (default=current)\n"
 						"  --display  (-d)  Select display # (default=main)\n"
-						"  --displays (-ld) List available displays\n"
-						"  --modes    (-lm) List available modes\n"
+						"  --displays (-l) List available displays\n"
+						"  --modes    (-m) List available modes\n"
 						"\nCurrently running GUI.  Use ^C or close from menu\n");
 		
 		NSAutoreleasePool* pool = [NSAutoreleasePool new];


### PR DESCRIPTION
Also prevents segfaults when missing parameters are passed.
Switching to getops forced changng nonstandard short comamnds
"-ld" and "-lm" to "-l" and "-m", respectively.